### PR TITLE
entrypoint.sh: Stop referring to the antiope pre-release header

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,7 +57,6 @@ request() {
     --connect-timeout 5 \
     --max-time 5 \
     --request "$method" \
-    --header 'Accept: application/vnd.github.antiope-preview+json' \
     --header "Authorization: token ${GITHUB_TOKEN}" \
     --header 'Content-Type: application/json' \
     --header 'User-Agent: github-actions' \


### PR DESCRIPTION
The feature was released, the specific header is no longer required:

https://developer.github.com/changes/2020-10-01-graduate-antiope-preview/